### PR TITLE
Update tableauxCong.php

### DIFF
--- a/tableauxCong.php
+++ b/tableauxCong.php
@@ -114,7 +114,7 @@ require 'required_files.inc.php';
 $year = (!empty($_GET['year']) ? sprintf("%04d", $_GET['year']) : date('Y'));
 $titre = "Congés";
 
-$affectation = $_SESSION['utilisateur']->affectationOnDate(date('Y') . '-01-01');
+$affectation = $_SESSION['utilisateur']->affectationOnDate(date('Y-m-d'));
 
 $users = utilisateursDeLaGrille::getInstance()->getActiveUsersFromTo("$year-01-01", "$year-12-31", $affectation['centre'], $affectation['team']);
 


### PR DESCRIPTION
Utilisation de la date courante au lieu du 1er janvier pour déterminer l'affectation de l'utilisateur connecté et avoir le tableau de congés de l'éaffectation courante et non de l'affectation au premier janvier de l'année.
