### PR TITLE
Modification du titre de la page des activités

### DIFF
--- a/activites.php
+++ b/activites.php
@@ -55,7 +55,7 @@ ob_start(); // Obligatoire pour firePHP
 /*
  * Configuration de la page
  */
-        $conf['page']['titre'] = sprintf("Liste mes heures"); // Le titre de la page
+        $conf['page']['titre'] = sprintf("Gestion des activités"); // Le titre de la page
 // Définit la valeur de $DEBUG pour le script
 // on peut activer le debug sur des parties de script et/ou sur certains scripts :
 // $DEBUG peut être activer dans certains scripts de required et désactivé dans d'autres


### PR DESCRIPTION
La page de gestion des activités était "liste mes heures", ce qui ne correspond pas à l'usage de la page...
