### PR TITLE
htmlentities inutile pour des mails texte

### DIFF
--- a/classes/class_email.inc.php
+++ b/classes/class_email.inc.php
@@ -179,7 +179,7 @@ class Email {
 			'to'		=> $row['email']
 			, 'subject'	=> $row['subject']
 			, 'content'	=> sprintf($row['texte']
-			, htmlentities(ucfirst($row['prenom']))
+			, ucfirst($row['prenom'])
 			, $array['proto']
 			, $_SERVER['SERVER_NAME']
 			, $row['k']
@@ -225,7 +225,7 @@ class Email {
 			'to'		=> $row['email']
 			, 'subject'	=> $row['subject']
 			, 'content'	=> sprintf($row['texte']
-			, htmlentities(ucfirst($row['prenom']))
+			, ucfirst($row['prenom'])
 			, $array['proto']
 			, $_SERVER['SERVER_NAME']
 			, $array['k']
@@ -265,8 +265,8 @@ class Email {
 			'to'		=> $array['to']
 			, 'subject'	=> $row['subject']
 			, 'content'	=> sprintf($row['texte']
-					, htmlentities(ucfirst($row['prenom']))
-					, htmlentities($row['login'])
+					, ucfirst($row['prenom'])
+					, $row['login']
 			)
 		);
 	}
@@ -303,10 +303,10 @@ class Email {
 			'to'		=> $row['email']
 			, 'subject'	=> $row['subject']
 			, 'content'	=> sprintf($row['texte']
-					, htmlentities(ucfirst($row['prenom']))
+					, ucfirst($row['prenom'])
 					, $array['proto']
 					, $_SERVER['SERVER_NAME']
-					, htmlentities($array['password'])
+					, $array['password']
 					)
 		);
 	}
@@ -341,7 +341,7 @@ class Email {
 			'to'		=> $row['email']
 			, 'subject'	=> $row['subject']
 			, 'content'	=> sprintf($row['texte']
-					, htmlentities(ucfirst($row['prenom']))
+					, ucfirst($row['prenom'])
 					, $array['proto']
 					, $_SERVER['SERVER_NAME']
 					, $k


### PR DESCRIPTION
Les mails ne sont pas au format html, htmlentities est donc inutile et crée des erreurs d'affichage dans les mails (prénoms et logins avec des accents)...
