### PR TITLE
Utilisation de "q" pour ajax.php

### DIFF
--- a/themes/anis/templates/confirmUser.tpl
+++ b/themes/anis/templates/confirmUser.tpl
@@ -13,7 +13,7 @@
 {$user.prenom|capitalize} <strong>{$user.nom|capitalize}</strong> ({$user.email})
 vient-il dans votre équipe ?
 </li><li>
-<input type="hidden" name="form" value="CU" />
+<input type="hidden" name="q" value="CU" />
 <input type="hidden" name="ajax" value="true" />
 <input type="hidden" name="cachemoi" value="1" />
 <input type="hidden" name="submit" value="confirm" id="subValue" />


### PR DESCRIPTION
La confirmation d'un nouveau compte utilisateur ne prenait pas en compte la nouvelle forme de requête "q" du script ajax.php.
